### PR TITLE
Add `enable` setting for ability to do project-specific disabling

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -124,6 +124,10 @@ export default {
             this.clearESLintCache();
           }
 
+          if (config.enabled) {
+            this.wake();
+          }
+
           if (config.scopes !== prevConfig.scopes) {
             this.scopes.splice(0, this.scopes.length);
             this.scopes.push(...config.scopes);
@@ -242,6 +246,7 @@ export default {
   },
 
   notifyAboutTimeout (timeoutError, editor = null) {
+    if (this.inactive) return;
     let forASpecificEditor = '';
     if (editor && editor.getPath) {
       forASpecificEditor = `for \`${editor.getPath()}\``;
@@ -401,6 +406,10 @@ export default {
   // file in place. Atom notices the file has changed and updates the buffer
   // contents.
   async fixJob (isSave = false) {
+    if (!Config.get('enable')) {
+      this.sleep(`Disabled in config`);
+      return;
+    }
     const textEditor = atom.workspace.getActiveTextEditor();
     if (!textEditor || !atom.workspace.isTextEditor(textEditor)) {
       return;
@@ -452,6 +461,10 @@ export default {
   },
 
   handleError (err, type, editor = null) {
+    if (!Config.get('enable')) {
+      this.sleep(`Disabled in config`);
+      return;
+    }
     if (err.name && err.name === 'TimeoutError') {
       // An operation timed out. We should tell the user but should not sleep
       // the worker, since we have no idea what caused the timeout or if it's
@@ -572,6 +585,10 @@ export default {
       lintsOnChange: true,
       grammarScopes: this.scopes,
       lint: async (textEditor) => {
+        if (!Config.get('enable')) {
+          this.sleep(`Disabled in config`);
+          return;
+        }
         console.warn('Linting', textEditor);
         if (!atom.workspace.isTextEditor(textEditor)) {
           return null;

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
       "title": "Enable",
       "description": "Whether to enable this package’s behavior. Provided as a way to disable linting for certain projects without having to disable the package.",
       "type": "boolean",
-      "default": false,
+      "default": true,
       "order": 0
     },
     "scopes": {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,13 @@
     "core:loaded-shell-environment"
   ],
   "configSchema": {
+    "enable": {
+      "title": "Enable",
+      "description": "Whether to enable this package’s behavior. Provided as a way to disable linting for certain projects without having to disable the package.",
+      "type": "boolean",
+      "default": false,
+      "order": 0
+    },
     "scopes": {
       "title": "List of scopes to run ESLint on",
       "description": "Run `Editor: Log Cursor Scope` to determine the scopes for a file. To lint JavaScript inside HTML files, add `source.js.embedded.html` to this list and be sure that `eslint-plugin-html` is installed and added to your `.eslintrc`.",

--- a/spec/linter-eslint-node-spec.js
+++ b/spec/linter-eslint-node-spec.js
@@ -265,7 +265,7 @@ describe('The eslint provider for Linter', () => {
       rimraf.sync(tempDir);
     });
 
-    it('will do nothing if the "enable" option is `false`', async () => {
+    it('will do nothing while "enable" option is `false`, but wake if "enable" is set to `true`', async () => {
       atom.config.set('linter-eslint-node.enable', false);
       const tempPath = await copyFileToTempDir(
         path.join(paths.eslintignoreDir, 'ignored.js')
@@ -275,8 +275,13 @@ describe('The eslint provider for Linter', () => {
       atom.config.set('linter-eslint-node.advanced.disableEslintIgnore', false);
       await copyFileToDir(path.join(paths.eslintignoreDir, '.eslintrc.yaml'), tempDir);
 
-      const messages = await lint(editor);
+      let messages = await lint(editor);
       expect(messages).toBeUndefined();
+
+      atom.config.set('linter-eslint-node.enable', true);
+      messages = await lint(editor);
+      expect(messages.length).toBe(1);
+
       rimraf.sync(tempDir);
     });
   });

--- a/spec/linter-eslint-node-spec.js
+++ b/spec/linter-eslint-node-spec.js
@@ -111,6 +111,7 @@ describe('The eslint provider for Linter', () => {
 
   beforeEach(async () => {
     atom.config.set('linter-eslint-node.advanced.disableEslintIgnore', true);
+    atom.config.set('linter-eslint-node.enable', true);
 
     // Activate activation hook
     atom.packages.triggerDeferredActivationHooks();
@@ -261,6 +262,21 @@ describe('The eslint provider for Linter', () => {
 
       const messages = await lint(editor);
       expect(messages.length).toBe(1);
+      rimraf.sync(tempDir);
+    });
+
+    it('will do nothing if the "enable" option is `false`', async () => {
+      atom.config.set('linter-eslint-node.enable', false);
+      const tempPath = await copyFileToTempDir(
+        path.join(paths.eslintignoreDir, 'ignored.js')
+      );
+      const tempDir = path.dirname(tempPath);
+      const editor = await atom.workspace.open(tempPath);
+      atom.config.set('linter-eslint-node.advanced.disableEslintIgnore', false);
+      await copyFileToDir(path.join(paths.eslintignoreDir, '.eslintrc.yaml'), tempDir);
+
+      const messages = await lint(editor);
+      expect(messages).toBeUndefined();
       rimraf.sync(tempDir);
     });
   });


### PR DESCRIPTION
I sometimes make contributions to projects which have very opinionated, noisy, or outdated ESLint configs. Sometimes they have silly ESLint plugins that I don't want to install. Sometimes I'm running `pulsar-ide-typescript-alpha` and the linting I'm getting from `typescript-language-server` is more than enough.

These are all scenarios in which I'd want a quick way to disable linting on an entire project (even when it's set up for ESLint) without disabling the package altogether. With an explicit **Enable** option, I can easily configure a project-specific override with `project-config`/`atomic-management` or by adding `"enable": false` to a `.linter-eslint` file.