### PR TITLE
replace not supported event.path with event.composedPath()

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -198,7 +198,7 @@ export default {
             // Black magic!
             // Compares the private component property of the active TextEditor
             //   against the components of the elements
-            const evtIsActiveEditor = evt.path.some((elem) => (
+            const evtIsActiveEditor = evt.composedPath().some((elem) => (
               // Atom v1.19.0+
               elem.component && activeEditor.component
                 && elem.component === activeEditor.component));


### PR DESCRIPTION
event.path is not supported in Electron 19 and later versions