### PR TITLE
Check `composedPath` instead of `path` in context menu handler

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -198,10 +198,11 @@ export default {
             // Black magic!
             // Compares the private component property of the active TextEditor
             //   against the components of the elements
-            const evtIsActiveEditor = evt.path.some((elem) => (
-              // Atom v1.19.0+
-              elem.component && activeEditor.component
-                && elem.component === activeEditor.component));
+            let eventPath = evt.path ?? evt.composedPath?.();
+            if (!eventPath) return false;
+            const evtIsActiveEditor = eventPath.some((elem) => (
+              elem.component && elem.component === activeEditor.component
+            ));
             // Only show if it was the active editor and it is a valid scope
             return evtIsActiveEditor && helpers.hasValidScope(activeEditor, Config.get('scopes'));
           }


### PR DESCRIPTION
A certain context menu item’s `shouldDisplay` handler uses “black magic” to determine if it should appear. To do this, it inspects `event.path` and assumes it will be present — but that property is not present in recent Chromium, so this causes an exception.

It seems to have been replaced with [the `event.composedPath()` method](https://developer.mozilla.org/en-US/docs/Web/API/Event/composedPath) — which, when called, returns a list of all the targets against which the event will fire during its bubbling phase.

Either way, if neither one somehow exists (or if our assumptions are violated) we should just return `false` early to prevent an exception.