### PR TITLE
Optimizations to fix-on-save

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -22,6 +22,9 @@ jobs:
         with:
           node-version: 'lts/*'
       - uses: volta-cli/action@v4
+      - name: Install prerequisites (Linux)
+        if: runner.os == 'Linux'
+        run: apt-get install libsecret-1-0
       - name: Install multiple Node versions
         if: runner.os != 'Windows'
         run: |

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -16,15 +16,15 @@ jobs:
           - macos-latest
           - windows-latest
     steps:
+      - name: Install prerequisites (Linux)
+        if: runner.os == 'Linux'
+        run: apt-get install libsecret-1-0
       - uses: actions/checkout@v3
       - uses: pulsar-edit/action-pulsar-dependency@v3.4
       - uses: actions/setup-node@v3
         with:
           node-version: 'lts/*'
       - uses: volta-cli/action@v4
-      - name: Install prerequisites (Linux)
-        if: runner.os == 'Linux'
-        run: apt-get install libsecret-1-0
       - name: Install multiple Node versions
         if: runner.os != 'Windows'
         run: |

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - name: Install prerequisites (Linux)
         if: runner.os == 'Linux'
-        run: apt-get install libsecret-1-0
+        run: sudo apt-get install libsecret-1-0
       - uses: actions/checkout@v3
       - uses: pulsar-edit/action-pulsar-dependency@v3.4
       - uses: actions/setup-node@v3

--- a/lib/buffer-version-tracker.js
+++ b/lib/buffer-version-tracker.js
@@ -1,0 +1,32 @@
+'use babel';
+
+import { CompositeDisposable } from 'atom';
+
+class BufferVersionTracker {
+  static BUFFERS = new WeakMap();
+
+  static forBuffer (buffer) {
+    return this.BUFFERS.get(buffer) ?? new BufferVersionTracker(buffer);
+  }
+
+  subscriptions = new CompositeDisposable();
+
+  constructor(buffer) {
+    BufferVersionTracker.BUFFERS.set(buffer, this);
+    this.version = 0;
+    this.subscriptions.add(
+      buffer.onDidChange(() => this.incrementBufferVersion()),
+      buffer.onDidDestroy(() => this.dispose())
+    );
+  }
+
+  incrementBufferVersion () {
+    this.version++;
+  }
+
+  dispose () {
+    this.subscriptions.dispose();
+  }
+}
+
+export default BufferVersionTracker;

--- a/lib/console.js
+++ b/lib/console.js
@@ -27,4 +27,9 @@ function makeConsoleMethod (name) {
   CONSOLE[name] = makeConsoleMethod(name);
 });
 
+CONSOLE.trace = (...args) => {
+  if (!isEnabled) return;
+  console.trace(...args);
+};
+
 export default CONSOLE;

--- a/lib/job-manager.js
+++ b/lib/job-manager.js
@@ -10,7 +10,9 @@ import Config from './config';
 import ndjson from 'ndjson';
 
 // How log we wait for a job to finish before giving up.
-const JOB_DURATION_TIMEOUT_MS = 15000;
+function getJobTimeout() {
+  return Config.get('advanced.jobDurationTimeoutMs') ?? 15000;
+}
 
 function generateKey () {
   return randomBytes(5).toString('hex');
@@ -32,15 +34,15 @@ class InvalidWorkerError extends Error {
 }
 
 class TimeoutError extends Error {
+  name = 'TimeoutError';
   constructor (duration) {
     super(`Operation timed out after ${duration}ms`);
-    this.name = 'TimeoutError';
     this.duration = duration;
   }
 }
 
 function rejectAfterDuration (duration) {
-  return new Promise((resolve, reject) => {
+  return new Promise((_, reject) => {
     setTimeout(() => {
       reject(new TimeoutError(duration));
     }, duration);
@@ -49,7 +51,7 @@ function rejectAfterDuration (duration) {
 
 function timeout (promise) {
   return Promise.race([
-    rejectAfterDuration(JOB_DURATION_TIMEOUT_MS),
+    rejectAfterDuration(getJobTimeout()),
     promise
   ]);
 }

--- a/lib/main.js
+++ b/lib/main.js
@@ -9,6 +9,7 @@ import console from './console';
 import Config from './config';
 import NodePathTester from './node-path-tester';
 import JobManager from './job-manager';
+import BufferVersionTracker from './buffer-version-tracker';
 import * as helpers from './helpers';
 
 const BUTTON_SETTINGS = {
@@ -48,7 +49,6 @@ export default {
 
   shouldAutoFix (textEditor) {
     if (this.inactive) { return false; }
-    if (textEditor.isModified()) { return false; }
     if (!Config.get('autofix.fixOnSave')) { return false; }
     if (!helpers.hasValidScope(textEditor, this.scopes)) { return false; }
     return true;
@@ -96,7 +96,7 @@ export default {
     this.subscriptions.add(
       atom.workspace.observeTextEditors(
         textEditor => {
-          textEditor.onDidSave(async () => {
+          textEditor.getBuffer().onWillSave(async () => {
             // Guard against multiple fires from the same save event. This can
             // happen when multiple tabs are open to the same file in different
             // panes.
@@ -420,10 +420,15 @@ export default {
     // explicitly ran the `Fix Job` command, so we should wake up.
     this.wake();
 
-    if (textEditor.isModified()) {
+    let wasModified = textEditor.isModified();
+    let buffer = textEditor.getBuffer();
+    let originalBufferVersion = BufferVersionTracker.forBuffer(buffer).version;
+
+    if (!isSave && textEditor.isModified()) {
       atom.notifications.addError(
         `linter-eslint-node: Please save before fixing.`
       );
+      return;
     }
 
     const filePath = textEditor.getPath();
@@ -431,10 +436,12 @@ export default {
 
     const text = textEditor.getText();
     // Don't try to fix an empty file.
-    if (text.length === 0) { return; }
+    if (text.length === 0) {
+      return;
+    }
 
     try {
-      const response = await this.jobManager.send({
+      let response = await this.jobManager.send({
         type: 'fix',
         config: Config.get(),
         contents: text,
@@ -444,11 +451,37 @@ export default {
         legacyPackagePresent: this.isLegacyPackagePresent()
       });
 
+      if (response.output) {
+        for (let [candidateFilePath, output] of Object.entries(response.output)) {
+          if (candidateFilePath !== filePath) continue;
+          if (!output) continue;
+
+          let latestBufferVersion = BufferVersionTracker.forBuffer(buffer).version;
+          if (latestBufferVersion !== originalBufferVersion) {
+            console.debug(`Skipping the fix of ${candidateFilePath} because it has been edited since the fix started`);
+            continue;
+          }
+
+          // Update the contents of the buffer in the least invasive way
+          // possible. This ensures stability of buffer markers when they are
+          // not affected by changes.
+          buffer.setTextViaDiff(output);
+
+          // Save the file if (a) it was unmodified when we ran the command,
+          // and (b) this isn't a lint-on-save operation. In the former case,
+          // we don't want to commit changes to disk that are unrelated to our
+          // fixes; in the latter case, we were triggered via `onWillSave` and
+          // the commit to disk will happen automatically.
+          if (!wasModified && !isSave) {
+            await buffer.save();
+          }
+        }
+      }
+
       let fixes = response.fixCount;
       let noun = fixes === 1 ? 'fix' : 'fixes';
 
       if (!isSave) {
-        // TODO: Check the response format.
         atom.notifications.addSuccess(
           fixes > 0 ?
             `Applied ${fixes} ${noun}.` :
@@ -462,6 +495,7 @@ export default {
   },
 
   handleError (err, type, editor = null) {
+    console.error('Handling error:', err, type);
     if (!Config.get('enable')) {
       this.sleep(`Disabled in config`);
       return;
@@ -583,14 +617,14 @@ export default {
     return {
       name: 'ESLint (Node)',
       scope: 'file',
-      lintsOnChange: true,
+      lintsOnChange: false,
       grammarScopes: this.scopes,
       lint: async (textEditor) => {
         if (!Config.get('enable')) {
           this.sleep(`Disabled in config`);
           return;
         }
-        console.warn('Linting', textEditor);
+        console.log('Linting editor', textEditor);
         if (!atom.workspace.isTextEditor(textEditor)) {
           return null;
         }
@@ -618,7 +652,7 @@ export default {
         const textBuffer = textEditor.getBuffer();
 
         try {
-          const response = await this.jobManager.send({
+          let response = await this.jobManager.send({
             type: 'lint',
             contents: text,
             config: Config.get(),
@@ -670,7 +704,6 @@ export default {
             filteredResults.push(result);
           }
 
-          console.debug('Linting results:', filteredResults);
           return filteredResults;
         } catch (err) {
           return this.handleError(err, 'lint', textEditor);

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -171,7 +171,7 @@ function getESLint (filePath, config, { isDebug, projectPath }) {
       let commonOptions = buildCommonConstructorOptions(config, resolveDir);
 
       const eslintLint = new ESLint({ ...commonOptions, fix: false });
-      const eslintFix = new ESLint({ ...commonOptions });
+      const eslintFix = new ESLint(commonOptions);
 
       Object.assign(bundle, { ESLint, eslintLint, eslintFix });
     }
@@ -199,15 +199,16 @@ async function lint (eslint, filePath, fileContent) {
   }
 }
 
-async function lintJob (meta, filePath, projectPath, fileContent) {
+async function lintJob (meta, filePath, _projectPath, fileContent) {
   const { eslintLint } = meta;
-  return lint(eslintLint, filePath, fileContent);
+  return await lint(eslintLint, filePath, fileContent);
 }
 
-async function fixJob (meta, filePath, projectPath, fileContent) {
-  const { ESLint, eslintFix } = meta;
+async function fixJob (meta, filePath, _projectPath, fileContent) {
+  const { eslintFix } = meta;
   const results = await lint(eslintFix, filePath, fileContent);
-  await ESLint.outputFixes(results);
+  // We used to write fixes to disk, but now we just return them to the
+  // renderer process so that the editor can update it during the save process.
   return results;
 }
 
@@ -227,9 +228,14 @@ function formatResults (files, rules, config, { isModified, key, isFixJob, lintM
     autofix: { ignoreFixableRulesWhileTyping },
     disabling: { rulesToSilenceWhileTyping = [] }
   } = config;
-  const results = [];
 
-  for (let { filePath, messages } of files) {
+  const results = [];
+  const outputByFile = {};
+
+  for (let { filePath, messages, output } of files) {
+    if (output) {
+      outputByFile[filePath] = output;
+    }
     for (let message of messages) {
       // Filter out any violations that the user has asked to ignore.
       if (isModified && ignoreFixableRulesWhileTyping && message.fix) {
@@ -278,8 +284,8 @@ function formatResults (files, rules, config, { isModified, key, isFixJob, lintM
       });
     }
   }
-  let result = { key, rules, results };
-  if (isFixJob && lintMessageCount) {
+  let result = { key, rules, results, output: outputByFile };
+  if (isFixJob) {
     result.fixCount = lintMessageCount - results.length;
   }
   return result;
@@ -365,9 +371,9 @@ async function processMessage (bundle) {
   }
 
   try {
-    let results, rules, lintMessageCount;
+    let results, rules, lintMessageCount, lintResults;
     if (type === 'fix') {
-      let lintResults = await lintJob(eslint, filePath, projectPath, contents, config);
+      lintResults = await lintJob(eslint, filePath, projectPath, contents, config);
       lintMessageCount = countMessages(lintResults);
       results = await fixJob(eslint, filePath, projectPath, contents, config);
       rules = eslint.eslintFix.getRulesMetaForResults(results);
@@ -376,15 +382,13 @@ async function processMessage (bundle) {
       rules = eslint.eslintLint.getRulesMetaForResults(results);
     }
 
-    emit(
-      formatResults(results, rules, config, {
-        isModified,
-        key,
-        isFixJob: type === 'fix',
-        lintMessageCount
-      })
-    );
-
+    let formattedResults = formatResults(results, rules, config, {
+      isModified,
+      key,
+      isFixJob: type === 'fix',
+      lintMessageCount
+    });
+    emit(formattedResults);
   } catch (error) {
     if (isConfigNotFoundError(error)) {
       emit({

--- a/package.json
+++ b/package.json
@@ -160,6 +160,13 @@
           "type": "boolean",
           "default": false,
           "order": 4
+        },
+        "jobDurationTimeoutMs": {
+          "title": "Job Duration Timeout",
+          "description": "How long (in milliseconds) to wait for a job to come back from the worker before raising an error. Increase this value as needed if you work in a very large project and linting takes longer than usual.",
+          "type": "number",
+          "default": 15000,
+          "order": 5
         }
       }
     }

--- a/spec/linter-eslint-node-spec.js
+++ b/spec/linter-eslint-node-spec.js
@@ -73,14 +73,6 @@ function getNotification(expectedMessage) {
  */
 async function makeFixes(textEditor, expectedFixCount) {
   const buffer = textEditor.getBuffer();
-  /** @type {Promise<void>} */
-  const editorReloadPromise = new Promise((resolve) => {
-    // Subscribe to file reload events
-    const editorReloadSubscription = buffer.onDidReload(() => {
-      editorReloadSubscription.dispose();
-      resolve();
-    });
-  });
 
   let expectedMessage;
   if (expectedFixCount === 0) {
@@ -101,8 +93,7 @@ async function makeFixes(textEditor, expectedFixCount) {
   expect(notification.getType()).toBe('success');
 
   // After editor reloads, it should be safe for consuming test to resume.
-  buffer.reload();
-  return editorReloadPromise;
+  await buffer.reload();
 }
 
 describe('The eslint provider for Linter', () => {
@@ -320,11 +311,11 @@ describe('The eslint provider for Linter', () => {
 
     beforeEach(async () => {
       atom.config.set('linter-eslint-node.advanced.useCache', false);
-      // Copy the file to a temporary folder
+      // Copy the file to a temporary folder.
       const tempFixturePath = await copyFileToTempDir(paths.fix);
       editor = await atom.workspace.open(tempFixturePath);
       tempDir = path.dirname(tempFixturePath);
-      // Copy the config to the same temporary directory
+      // Copy the config to the same temporary directory.
       await copyFileToDir(paths.config, tempDir);
     });
 
@@ -339,7 +330,7 @@ describe('The eslint provider for Linter', () => {
      */
     async function firstLint(textEditor) {
       const messages = await lint(textEditor);
-      // The original file has two errors
+      // The original file has two errors.
       expect(messages.length).toBe(2);
     }
 
@@ -362,6 +353,20 @@ describe('The eslint provider for Linter', () => {
       expect(messagesAfterFixing.length).toBe(1);
       expect(messagesAfterFixing[0].excerpt).toBe(expected);
       expect(messagesAfterFixing[0].url).toBe(expectedUrl);
+    });
+
+    describe('on save', () => {
+      beforeEach(() => {
+        atom.config.set('linter-eslint-node.autofix.fixOnSave', true);
+      });
+
+      it('auto-fixes on save', async () => {
+        editor.setCursorBufferPosition([Infinity, Infinity]);
+        editor.getLastSelection().insertText('\n');
+        expect(editor.isModified()).toBe(true);
+        await editor.save();
+        expect(editor.getText()).not.toContain(';');
+      });
     });
   });
 


### PR DESCRIPTION
I started a new job recently with an absolutely gigantic TypeScript project with lots of generated types. The process of linting and fixing takes long enough — a matter of at least a few seconds — that our way of handing auto-fixing was causing some issues.

Most notably: it was very strange to save the file and then see it update again a few seconds later. And having the buffer reload as a result of a filesystem event would very occasionally trigger a very disruptive flash of content.

On my work machine, I hacked on the package and made a bunch of changes that seemed to improve the quality of my editing experience. Only tonight when I tried to apply them all in a batch did I realize that most of them either didn't do anything or caused various specs to fail.

But the main fix that remains: this PR makes it so that fix-on-save hooks into the asynchronous save process. Instead of attaching to `TextEditor::onDidSave`, we attach to `TextBuffer::onWillSave`.

The latter is one of the few event subscription methods that explicitly allows its callbacks to go async… and does not proceed until all such callbacks have resolved. This is for our exact purpose — to allow packages such as ours to make last-minute changes to the buffer before it is committed to disk.

To compensate, the worker no longer is responsible for writing the fixes to disk. Instead it just figures out what the output should be for each file and communicates it back to the renderer process.

---

A future enhancement to keep in mind: I started playing around with the idea of reusing linting jobs. For instance, in an an unusual case where linting gets triggered twice in rapid succession for the same buffer, they should reuse the same job instead of triggering two separate lints (as long as the buffer has not been modified in between).
  
In theory, a _lint_ job should be able to reuse the results of a _fix_ job (though not vice-versa). I haven't been able to get this working just yet without introducing some spec violations, but it could be a high-value optimization, since fix-on-save will immediately trigger a re-linting because linting always happens on save.